### PR TITLE
Setup codecov for tracking coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,13 +39,3 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-
-  coveralls_finish:
-    needs: build-and-test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Coveralls Finished
-        uses: AndreMiras/coveralls-python-action@develop
-        with:
-          parallel-finished: true
-          debug: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,14 +35,10 @@ jobs:
           pip install nox
           nox --non-interactive --error-on-missing-interpreter -s test
 
-      - name: Coveralls
-        if: matrix.os == 'ubuntu-latest'
-        uses: AndreMiras/coveralls-python-action@develop
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
         with:
-          parallel: true
-          flag-name: py${{ matrix.python-version }}-${{ matrix.os }}
-
-          debug: true
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   coveralls_finish:
     needs: build-and-test

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,14 +13,8 @@ def test(session: nox.Session) -> None:
     """Run the tests."""
     session.install(".[testing]")
 
-    args = ["--cov", "sensible_bmi", "-vvv"] + session.posargs
-
-    if "CI" in os.environ:
-        args.append(f"--cov-report=xml:{ROOT}/coverage.xml")
-    session.run("pytest", *args)
-
-    if "CI" not in os.environ:
-        session.run("coverage", "report", "--ignore-errors", "--show-missing")
+    session.run("pytest", "--cov-branch", f"--cov-report=xml:{ROOT}/coverage.xml")
+    session.run("coverage", "report", "--ignore-errors", "--show-missing")
 
 
 @nox.session


### PR DESCRIPTION
We had been using *coveralls* for tracking our coverage but I thought it would be worth trying *codecov*.