### PR TITLE
Add comparison operators for the SensibleTime class

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -13,7 +13,14 @@ def test(session: nox.Session) -> None:
     """Run the tests."""
     session.install(".[testing]")
 
-    session.run("coverage", "run", "--branch", "--module", "pytest")
+    session.run(
+        "coverage",
+        "run",
+        "--branch",
+        "--source=sensible_bmi,tests",
+        "--module",
+        "pytest",
+    )
     session.run("coverage", "report", "--ignore-errors", "--show-missing")
     session.run("coverage", "xml", "-o", "coverage.xml")
 

--- a/src/sensible_bmi/_time.py
+++ b/src/sensible_bmi/_time.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import math
 import pprint
+from functools import total_ordering
 
 from bmipy.bmi import Bmi
 
 
+@total_ordering
 class SensibleTime:
     def __init__(self, bmi: Bmi):
         self._units = bmi.get_time_units()
@@ -47,3 +50,19 @@ class SensibleTime:
                 "current": self.current,
             }
         )
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, SensibleTime):
+            return math.isclose(self.current, other.current)
+        elif isinstance(other, (int, float)):
+            return math.isclose(self.current, other)
+        else:
+            return NotImplemented
+
+    def __lt__(self, other: object) -> bool:
+        if isinstance(other, SensibleTime):
+            return self.current < other.current
+        elif isinstance(other, (float, int)):
+            return self.current < other
+        else:
+            return NotImplemented

--- a/src/sensible_bmi/_time.py
+++ b/src/sensible_bmi/_time.py
@@ -9,6 +9,8 @@ from bmipy.bmi import Bmi
 
 @total_ordering
 class SensibleTime:
+    __slots__ = ("_units", "_start", "_stop", "_step", "_bmi")
+
     def __init__(self, bmi: Bmi):
         self._units = bmi.get_time_units()
         self._start = bmi.get_start_time()

--- a/tests/time_test.py
+++ b/tests/time_test.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+from sensible_bmi._time import SensibleTime
+
+
+def bmi_time(units="s", start=0.0, stop=1.0, step=1.0, current=None):
+    mock = Mock()
+    mock.get_time_units.return_value = units
+    mock.get_start_time.return_value = start
+    mock.get_end_time.return_value = stop
+    mock.get_time_step.return_value = step
+    mock.get_current_time.return_value = start if current is None else current
+
+    return mock
+
+
+def test_time():
+    time = SensibleTime(bmi_time(units="s", start=1.0, stop=10.0, step=0.1))
+
+    assert time.units == "s"
+    assert time.start == 1.0
+    assert time.stop == 10.0
+    assert time.step == 0.1
+    assert time.current == time.start
+
+
+@pytest.mark.parametrize("time_2", (SensibleTime(bmi_time(current=2.0)), 2.0))
+def test_comparisons_unequal(time_2):
+    time_1 = SensibleTime(bmi_time(current=1.0))
+
+    assert time_1 < time_2
+    assert time_1 <= time_2
+    assert time_2 > time_1
+    assert time_2 >= time_1
+    assert time_1 != time_2
+
+
+@pytest.mark.parametrize("time_2", (SensibleTime(bmi_time(current=2.0)), 2.0))
+def test_comparisons_equal(time_2):
+    time_1 = SensibleTime(bmi_time(current=2.0))
+
+    assert time_1 <= time_2
+    assert time_2 >= time_1
+    assert time_1 == time_2
+
+
+# @pytest.mark.parametrize("bad_value", ("two", True))
+@pytest.mark.parametrize("bad_value", ("two", None))
+def test_comparison_with_not_time_like(bad_value):
+    time = SensibleTime(bmi_time(current=2.0))
+
+    with pytest.raises(TypeError):
+        time < bad_value  # noqa: B015
+    with pytest.raises(TypeError):
+        time > bad_value  # noqa: B015
+    with pytest.raises(TypeError):
+        time <= bad_value  # noqa: B015
+    with pytest.raises(TypeError):
+        time >= bad_value  # noqa: B015
+    assert not (time == bad_value)
+    assert time != bad_value
+
+
+def test_str():
+    time = SensibleTime(bmi_time(units="s", start=1.0, stop=10.0, step=0.1))
+
+    actual = eval(str(time))
+    assert actual["units"] == time.units
+    assert actual["start"] == time.start
+    assert actual["stop"] == time.stop
+    assert actual["step"] == time.step
+
+
+def test_repr():
+    time = SensibleTime(bmi_time(units="s", start=1.0, stop=10.0, step=0.1))
+
+    actual = repr(time)
+    assert actual.startswith("SensibleTime(") and actual.endswith(")")


### PR DESCRIPTION
I've added some comparison operators for `SensibleTime`. One can now compare a `SensibleTime` object with another `SensibleTime` or a number, which compares to the current time.
