### PR TITLE
Add new zeros, ones, and full array creators for SensibleVar

### DIFF
--- a/src/sensible_bmi/_var.py
+++ b/src/sensible_bmi/_var.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import numpy as np
 from bmipy.bmi import Bmi
+from numpy.typing import ArrayLike
 from numpy.typing import NDArray
 
 
@@ -75,6 +76,9 @@ class SensibleVar:
 
     def ones(self) -> NDArray[Any]:
         return np.ones(self._size, dtype=self._type)
+
+    def full(self, fill_value: ArrayLike) -> NDArray[Any]:
+        return np.full(self._size, fill_value, dtype=self._type)
 
     def __repr__(self) -> str:
         return os.linesep.join(

--- a/src/sensible_bmi/_var.py
+++ b/src/sensible_bmi/_var.py
@@ -73,6 +73,9 @@ class SensibleVar:
     def zeros(self) -> NDArray[Any]:
         return np.zeros(self._size, dtype=self._type)
 
+    def ones(self) -> NDArray[Any]:
+        return np.ones(self._size, dtype=self._type)
+
     def __repr__(self) -> str:
         return os.linesep.join(
             [f"{self.__class__.__name__}({self._bmi!r}, {self._name!r})", str(self)]

--- a/src/sensible_bmi/_var.py
+++ b/src/sensible_bmi/_var.py
@@ -101,7 +101,8 @@ class SensibleVar:
 
 
 class SensibleInputVar(SensibleVar):
-    def set(self, values: NDArray[Any]) -> None:
+    def set(self, values: ArrayLike) -> None:
+        values = np.asarray(values).reshape(-1)
         self._bmi.set_value(
             self._name, np.broadcast_to(values, self._nbytes // self.itemsize)
         )

--- a/src/sensible_bmi/_var.py
+++ b/src/sensible_bmi/_var.py
@@ -70,6 +70,9 @@ class SensibleVar:
     def empty(self) -> NDArray[Any]:
         return np.empty(self._size, dtype=self._type)
 
+    def zeros(self) -> NDArray[Any]:
+        return np.zeros(self._size, dtype=self._type)
+
     def __repr__(self) -> str:
         return os.linesep.join(
             [f"{self.__class__.__name__}({self._bmi!r}, {self._name!r})", str(self)]


### PR DESCRIPTION
The `SensibleVar` class can allocate uninitialized memory using the `empty` method but I thought it would be nice if we, additionally, had `zeros`, `ones`, and `full` methods that allocated and initialized memory.