### PR TITLE
Add out keyword to get method of SensibleOutputVar

### DIFF
--- a/src/sensible_bmi/_var.py
+++ b/src/sensible_bmi/_var.py
@@ -113,10 +113,11 @@ class SensibleOutputVar(SensibleVar):
     # def data(self) -> NDArray[Any]:
     #     return self._data_read_only
 
-    def get(self) -> NDArray[Any]:
-        values = self.empty()
-        self._bmi.get_value(self._name, values)
-        return values
+    def get(self, out: NDArray[Any] | None = None) -> NDArray[Any]:
+        if out is None:
+            out = self.empty()
+        self._bmi.get_value(self._name, out)
+        return out
 
     def __str__(self) -> str:
         # with np.printoptions(threshold=6):

--- a/tests/var_test.py
+++ b/tests/var_test.py
@@ -91,6 +91,19 @@ def test_var_out(cls):
     assert array.size == var.size
 
 
+@pytest.mark.parametrize("cls", (SensibleInputOutputVar, SensibleOutputVar))
+def test_var_out_with_keyword(cls):
+    expected = np.zeros(10)
+    var = cls(bmi_var(expected, itemsize=8, dtype="float64", nbytes=8 * 10), "bar")
+
+    actual = var.empty()
+    actual.fill(1.0)
+    rtn = var.get(out=actual)
+
+    assert np.allclose(actual, expected)
+    assert rtn is actual
+
+
 @pytest.mark.parametrize("cls", (SensibleInputVar,))
 @pytest.mark.parametrize(
     "dtype", ("float", "int", "uint", "uint8", "f4,i2", "f", "B", "bool", "complex")


### PR DESCRIPTION
I've added an optional `out` keyword to the `SensibleOutputVar.get` method that allows a user to pass a pre-allocated array into which the retrieved data are placed. If not provided, `get` returns a newly-allocated array.