### PR TITLE
Allow vars to not have grids

### DIFF
--- a/src/sensible_bmi/_var.py
+++ b/src/sensible_bmi/_var.py
@@ -28,7 +28,11 @@ class SensibleVar:
         self._name = name
         self._units = bmi.get_var_units(name)
         self._location = bmi.get_var_location(name)
-        self._grid = None if self._location == "none" else bmi.get_var_grid(name)
+        if self._location == "none":
+            self._location = None
+            self._grid = None
+        else:
+            self._grid = bmi.get_var_grid(name)
         self._itemsize = bmi.get_var_itemsize(name)
         self._type = _normalize_dtype(bmi.get_var_type(name), self._itemsize)
         self._nbytes = bmi.get_var_nbytes(name)
@@ -45,7 +49,7 @@ class SensibleVar:
         return self._units
 
     @property
-    def location(self) -> str:
+    def location(self) -> str | None:
         return self._location
 
     @property

--- a/tests/var_test.py
+++ b/tests/var_test.py
@@ -46,6 +46,16 @@ def test_var(cls):
     assert var.size == 5
 
 
+@pytest.mark.parametrize(
+    "cls", (SensibleInputOutputVar, SensibleOutputVar, SensibleInputVar)
+)
+def test_var_without_grid(cls):
+    var = cls(bmi_var(np.ones(5), location="none"), "foo")
+
+    assert var.location is None
+    assert var.grid is None
+
+
 @pytest.mark.parametrize("cls", (SensibleInputOutputVar, SensibleOutputVar))
 @pytest.mark.parametrize(
     "dtype", ("float", "int", "uint", "uint8", "f4,i2", "f", "B", "bool", "complex")


### PR DESCRIPTION
If a BMI variables doesn't have a grid (i.e. `get_var_location` returns the string `"none"`), then its grid is set to `None`. In addition, the variable's location is also set to `None`.