### PR TITLE
Fix ci by removing unsupported nox flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Test
         run: |
           pip install nox
-          nox --non-interactive --error-on-missing-interpreter -s test -- dist/*.tar.gz
+          nox --non-interactive -s test -- dist/*.tar.gz
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
The CI began failing with the following error,
```
nox: error: unrecognized arguments: --error-on-missing-interpreter
```
This option is no longer a thing and it wasn't necessary so I removed it. 