### PR TITLE
Manage package version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [project]
 name = "sensible_bmi"
+version = "0.1.0"
 requires-python = ">=3.10"
 description = "Pythonic wrapper for the Basic Model Interface"
 keywords = [
@@ -30,7 +31,6 @@ dependencies = [
     "numpy",
 ]
 dynamic = [
-    "version",
     "readme",
 ]
 
@@ -51,9 +51,6 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.dynamic.readme]
 file = "README.md"
 content-type = "text/markdown"
-
-[tool.setuptools.dynamic.version]
-attr = "sensible_bmi._version.__version__"
 
 [project.optional-dependencies]
 dev = [

--- a/src/sensible_bmi/_version.py
+++ b/src/sensible_bmi/_version.py
@@ -1,3 +1,9 @@
 from __future__ import annotations
 
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version
+
+try:
+    __version__ = version("sensible-bmi")
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "unknown"


### PR DESCRIPTION
I've moved the version into `pyproject.toml` because that seems like a better place to manage the version.