### PR TITLE
Update license metadata for pep639

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,8 @@
 [project]
 name = "sensible_bmi"
 version = "0.1.0"
+license = "MIT"
+license-files = ["LICENSE.md"]
 requires-python = ">=3.10"
 description = "Pythonic wrapper for the Basic Model Interface"
 keywords = [
@@ -16,7 +18,6 @@ maintainers = [
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.10",
@@ -33,9 +34,6 @@ dependencies = [
 dynamic = [
     "readme",
 ]
-
-[project.license]
-text = "MIT"
 
 [project.urls]
 documentation = "https://github.com/mcflugen/sensible-bmi"


### PR DESCRIPTION
I've updated the license metadata to follow *PEP639*.