### PR TITLE
Publish to PyPI/TestPyPI on manual trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,37 +1,24 @@
 name: Test
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: ["**"]
+  workflow_dispatch:
+    inputs:
+      publish_to:
+        description: "Where to publish"
+        type: choice
+        required: true
+        default: none
+        options:
+          - none
+          - testpypi
+          - pypi
 
 jobs:
-  check-tag:
-    # Run on external PRs, but not on internal PRs, to avoid duplicate runs
-    if: |
-      github.event_name == 'push' ||
-      github.event.pull_request.head.repo.full_name != github.repository
-
-    runs-on: ubuntu-latest
-    outputs:
-      publish_url: ${{ steps.check-publish.outputs.publish_url }}
-
-    steps:
-      - name: Check if this is a release/prerelease
-        id: check-publish
-        run: |
-          tag_name="${GITHUB_REF#refs/tags/}"
-          if [[ "$tag_name" =~ ^v[0-9]+\.[0-9]+\.[0-9]+[ab][0-9]+$ ]]; then
-            publish_url="https://test.pypi.org/legacy/"
-          elif [[ "$tag_name" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            publish_url="https://upload.pypi.org/legacy/"
-          else
-            publish_url="none"
-          fi
-          echo "publish_url=$publish_url" >> "$GITHUB_OUTPUT"
-          echo "tag_name=$tag_name"
-          echo "publish_url=$publish_url"
-
   build-sdist:
     name: Build source distribution
-    needs: check-tag
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -136,3 +123,32 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+  publish:
+    needs:
+      - test
+      - build-sdist
+    name: "Publish to PyPI/TestPyPI"
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && inputs.publish_to != 'none'
+    env:
+      REPOSITORY_URL: ${{ inputs.publish_to == 'testpypi' && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
+
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: "build-*"
+          merge-multiple: true
+          path: ${{ github.workspace }}/dist
+
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: ${{ env.REPOSITORY_URL }}
+          packages-dir: dist
+          skip-existing: true
+          print-hash: true
+          verify-metadata: false


### PR DESCRIPTION
I've added a publish step to the CI that publishes a release to *PyPI* or *TestPyPI* only on a manual trigger.